### PR TITLE
Fix typo in the packageName example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can set the package name by defining the `packageName` options:
 ```JSON
 {
   "plugins": [
-    ["babel-plugin-classnames", { "packageName": "dss-classname" }]
+    ["babel-plugin-classnames", { "packageName": "dss-classnames" }]
   ]
 }
 ```


### PR DESCRIPTION
The correct package name is dss-classnames

ping @giuseppeg :)