### PR TITLE
Add `importName` option to support non-default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ import _classNames from 'classnames'
 <div className={_classNames('btn', props.large && 'large')} />
 ```
 
-By default imports from `classname`. However the package name is configurable.
+By default imports from `classnames`. However the package name is configurable.
 
-## installation
+## Installation
 
 ```
 npm i --save-dev babel-plugin-classnames
@@ -35,14 +35,27 @@ Then add the plugin to your `.babelrc` file:
 }
 ```
 
-## Configuring the package name
+## Configuring the package and import name
 
-You can set the package name by defining the `packageName` options:
+You can set the package name by defining the `packageName` option:
 
 ```JSON
 {
   "plugins": [
     ["babel-plugin-classnames", { "packageName": "dss-classnames" }]
+  ]
+}
+```
+
+If the function you want to use is not the default package export you can use the `importName` option:
+
+```JSON
+{
+  "plugins": [
+    ["babel-plugin-classnames", {
+      "packageName": "emotion",
+      "importName": "cx"
+    }]
   ]
 }
 ```

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ function babelPluginClassNames({ types: t }) {
           if (state.hasClassNames) {
             const importDeclaration = t.importDeclaration(
               [
-                !state.opts.importName || state.opts.importName === 'default'
-                  ? t.importDefaultSpecifier(state.classNamesIdentifier)
-                  : t.importSpecifier(
-                    state.classNamesIdentifier,
-                    t.identifier(state.opts.importName)
-                  )
+                state.opts.importName
+                ? t.importSpecifier(
+                  state.classNamesIdentifier,
+                  t.identifier(state.opts.importName)
+                )
+                : t.importDefaultSpecifier(state.classNamesIdentifier)
               ],
               t.stringLiteral(state.opts.packageName || 'classnames')
             )

--- a/index.js
+++ b/index.js
@@ -10,7 +10,14 @@ function babelPluginClassNames({ types: t }) {
         exit(path, state) {
           if (state.hasClassNames) {
             const importDeclaration = t.importDeclaration(
-              [t.importDefaultSpecifier(state.classNamesIdentifier)],
+              [
+                !state.opts.importName || state.opts.importName === 'default'
+                  ? t.importDefaultSpecifier(state.classNamesIdentifier)
+                  : t.importSpecifier(
+                    state.classNamesIdentifier,
+                    t.identifier(state.opts.importName)
+                  )
+              ],
               t.stringLiteral(state.opts.packageName || 'classnames')
             )
 

--- a/test.js
+++ b/test.js
@@ -26,6 +26,21 @@ classNames(a, b && foo);
 })
 
 transform(`
+<div className={[a,b && fo]} />;
+`.trim(), { plugins: ["@babel/plugin-syntax-jsx", [plugin, { importName: 'cx' }]] }, (err, result) => {
+  if (err) {
+    throw err
+  }
+  assert.equal(
+    result.code,
+    `
+import { cx as _classNames } from "classnames";
+<div className={_classNames(a, b && fo)} />;
+    `.trim()
+  )
+})
+
+transform(`
 <div className={[a,b && fo]}><div className={[styles.foo]} /></div>;
 `.trim(), { presets: ["@babel/env"],  plugins: ["@babel/plugin-syntax-jsx", plugin] }, (err, result) => {
   if (err) {


### PR DESCRIPTION
Hey 👋 great plugin!

I was hoping to use it with [emotion’s `cx` function](https://github.com/emotion-js/emotion/blob/master/docs/cx.md) – this PR adds an `importName` option which allows using non-default package exports (e.g. `import { cx } from 'emotion'`)

```json
{
  "plugins": [
    ["babel-plugin-classnames", {
      "packageName": "emotion",
      "importName": "cx"
    }]
  ]
}
```

```js
<div className={[a,b && fo]} />;

// ↓↓↓↓↓↓↓↓

import { cx as _classNames } from "emotion";
<div className={_classNames(a, b && fo)} />;
```

Let me know if anything needs changing!

Thanks,
Brad