### PR TITLE
Add option to wrap objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,27 @@ If the function you want to use is not the default package export you can use th
   ]
 }
 ```
+
+If you want objects to be transformed, you can opt into it with the `transformObjects` option:
+
+```JSON
+{
+  "plugins": [
+    ["babel-plugin-classnames", { "transformObjects": true }]
+  ]
+}
+```
+
+With this option enabled this:
+
+```js
+<div className={{ btn: true, large: props.large }} />
+```
+
+becomes:
+
+```js
+import _classNames from 'classnames'
+
+<div className={_classNames({ btn: true, large: props.large })} />
+```

--- a/index.js
+++ b/index.js
@@ -36,16 +36,25 @@ function babelPluginClassNames({ types: t }) {
         }
 
         const expression = value.get('expression')
-        if (!expression.isArrayExpression()) {
+        if (expression.isArrayExpression()) {
+          expression.replaceWith(
+            t.callExpression(
+              cloneNode(state.classNamesIdentifier),
+              expression.get('elements').map(e => cloneNode(e.node)),
+            )
+          )
+        } else if (state.opts.transformObjects && expression.isObjectExpression()) {
+          expression.replaceWith(
+            t.callExpression(
+              cloneNode(state.classNamesIdentifier),
+              [cloneNode(expression.node)]
+            )
+          )
+        } else {
           return
         }
 
-        expression.replaceWith(
-          t.callExpression(
-            cloneNode(state.classNamesIdentifier),
-            expression.get('elements').map(e => cloneNode(e.node)),
-          )
-        )
+
 
         state.hasClassNames = true
       }

--- a/test.js
+++ b/test.js
@@ -25,6 +25,7 @@ classNames(a, b && foo);
   )
 })
 
+
 transform(`
 <div className={[a,b && fo]} />;
 `.trim(), { plugins: ["@babel/plugin-syntax-jsx", [plugin, { importName: 'cx' }]] }, (err, result) => {
@@ -40,8 +41,25 @@ import { cx as _classNames } from "classnames";
   )
 })
 
+
 transform(`
-<div className={{ foo: true }} />;
+<div className={[a,b && fo]} />;
+`.trim(), { plugins: ["@babel/plugin-syntax-jsx", [plugin, { packageName: 'foo' }]] }, (err, result) => {
+  if (err) {
+    throw err
+  }
+  assert.equal(
+    result.code,
+    `
+import _classNames from "foo";
+<div className={_classNames(a, b && fo)} />;
+    `.trim()
+  )
+})
+
+
+transform(`
+<div className={{ foo }} />;
 `.trim(), { plugins: ["@babel/plugin-syntax-jsx", [plugin, { transformObjects: true }]] }, (err, result) => {
   if (err) {
     throw err
@@ -51,14 +69,15 @@ transform(`
     `
 import _classNames from "classnames";
 <div className={_classNames({
-  foo: true
+  foo
 })} />;
     `.trim()
   )
 })
 
+
 transform(`
-<div className={{ foo: true }} />;
+<div className={{ foo }} />;
 `.trim(), { plugins: ["@babel/plugin-syntax-jsx", [plugin, { transformObjects: false }]] }, (err, result) => {
   if (err) {
     throw err
@@ -67,11 +86,12 @@ transform(`
     result.code,
     `
 <div className={{
-  foo: true
+  foo
 }} />;
     `.trim()
   )
 })
+
 
 transform(`
 <div className={[a,b && fo]}><div className={[styles.foo]} /></div>;

--- a/test.js
+++ b/test.js
@@ -41,6 +41,39 @@ import { cx as _classNames } from "classnames";
 })
 
 transform(`
+<div className={{ foo: true }} />;
+`.trim(), { plugins: ["@babel/plugin-syntax-jsx", [plugin, { transformObjects: true }]] }, (err, result) => {
+  if (err) {
+    throw err
+  }
+  assert.equal(
+    result.code,
+    `
+import _classNames from "classnames";
+<div className={_classNames({
+  foo: true
+})} />;
+    `.trim()
+  )
+})
+
+transform(`
+<div className={{ foo: true }} />;
+`.trim(), { plugins: ["@babel/plugin-syntax-jsx", [plugin, { transformObjects: false }]] }, (err, result) => {
+  if (err) {
+    throw err
+  }
+  assert.equal(
+    result.code,
+    `
+<div className={{
+  foo: true
+}} />;
+    `.trim()
+  )
+})
+
+transform(`
 <div className={[a,b && fo]}><div className={[styles.foo]} /></div>;
 `.trim(), { presets: ["@babel/env"],  plugins: ["@babel/plugin-syntax-jsx", plugin] }, (err, result) => {
   if (err) {


### PR DESCRIPTION
I've been testing this plugin for a few days on our website and I've been loving it! In my testing, however, I have found cases where the below example happens, and it feels verbose to me.

```jsx
const {
  foo,
  bar,
} = props

<div className={[{ [styles.foo]: foo, [styles.bar]: bar }]} />
```

This is especially true in complex cases where we have to split `className` into multiple lines. Our org's style guide requires new lines for multi-line object expressions, so the example above would become: 

```jsx
<div 
  className={
    [
      { 
        [styles.foo]: foo, 
        [styles.bar]: bar
      }
    ]
  } />
```


This PR introduces the option `transformObjects` so that `className` may be written like:
 
```jsx
<div 
  className={    
    { 
      [styles.foo]: foo, 
      [styles.bar]: bar
    }
  } />
```

and would be transformed into:

```jsx
<div 
  className={    
    _classNames({ 
      [styles.foo]: foo, 
      [styles.bar]: bar
    })
  } />
```


I have also written test cases for this option, and introduced an additional test case for `packageName` since there wasn't one there before.